### PR TITLE
Implement displaying tree view of model description

### DIFF
--- a/class-diagram/class-diagram.mmd
+++ b/class-diagram/class-diagram.mmd
@@ -20,8 +20,10 @@ class ThermalModel {
 
 class Node {
     -Float temperature
+    +Dict parameters
     +computeHeatExchange()
     +getTemperature() Float
+    +Node(parameters)
 }
 
 class HeatStorageNode {

--- a/class-diagram/class-diagram.mmd
+++ b/class-diagram/class-diagram.mmd
@@ -12,6 +12,7 @@ class ThermalModel {
     -addInterfaceLinks(nameHSN, nameIFN, List~(name, target, linkeTypes, parameters)~ links)
     +simulate()
     +save(filename?)
+    +display()
     -createMatrices()
     -addTemperatureReading()
     +ThermalModel(simulation_duration, timestep, model_description)

--- a/example-simulation.py
+++ b/example-simulation.py
@@ -181,9 +181,11 @@ thermalmodel = tm.ThermalModel(
     model_description=model_description,
 )
 
+thermalmodel.display()
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #                                 Run Simulation
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-thermalmodel.simulate()
-thermalmodel.save()
+# thermalmodel.simulate()
+# thermalmodel.save()

--- a/thermalmodel/nodes.py
+++ b/thermalmodel/nodes.py
@@ -10,8 +10,9 @@ from .links import Link, LinkType
 
 class Node():
 
-    def __init__(self):
+    def __init__(self, parameters: Dict):
         self._temperature: float = 0
+        self.parameters: Dict = {}
 
     def computeHeatExchange(self):
         return NotImplementedError()
@@ -23,7 +24,8 @@ class Node():
 class HeatStorageNode(Node):
 
     def __init__(self, parameters: dict):
-        super().__init__()
+        super().__init__(parameters)
+        self.parameters: Dict = parameters
 
         self._timestep: float = parameters.get('timestep', 1)
 
@@ -67,7 +69,7 @@ class HeatStorageNode(Node):
 class InterfaceNode(Node):
 
     def __init__(self, referenceNode: HeatStorageNode, parameters: dict):
-        super().__init__()
+        super().__init__(parameters)
 
         self.referenceNode: HeatStorageNode = referenceNode
 

--- a/thermalmodel/thermalmodel.py
+++ b/thermalmodel/thermalmodel.py
@@ -5,8 +5,8 @@ import numpy as np
 import pandas as pd
 import itertools
 
-from .nodes import HeatStorageNode, LinkType, Node
-from .links import ManualLink
+from .nodes import HeatStorageNode, InterfaceNode, LinkType, Node
+from .links import Link, ManualLink
 
 
 class ThermalModel():
@@ -212,7 +212,19 @@ class ThermalModel():
         indent = { k: ' ' * v + '- ' for k, v in indentspaces.items() }
         paramsindent = { k: ' ' * v + '  ' for k, v in indentspaces.items() }
 
-        def printParams(parameters: Dict[str, Node], level: str):
+        def printParams(parameters: Dict, level: str):
+            if level == 'link':
+                for k, v in parameters.items():
+                    if k == 'node1' or k == 'node2':
+                        ifn: InterfaceNode = v
+                        hsn: HeatStorageNode = ifn.referenceNode
+                        hsn_ifn_element: Tuple[str, InterfaceNode] = tuple(filter(
+                            lambda i: i[1] is v,
+                            hsn.interfaces.items()
+                        ))[0]
+                        v = '{} {}'.format(hsn_ifn_element[0], hsn_ifn_element[1])
+                    print('{}{}: {}'.format(paramsindent[level], k, v))
+                return
             for k, v in parameters.items():
                 print('{}{}: {}'.format(paramsindent[level], k, v))
 

--- a/thermalmodel/thermalmodel.py
+++ b/thermalmodel/thermalmodel.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 import itertools
 
-from .nodes import HeatStorageNode, LinkType
+from .nodes import HeatStorageNode, LinkType, Node
 from .links import ManualLink
 
 
@@ -210,10 +210,20 @@ class ThermalModel():
             'link': 8,
         }
         indent = { k: ' ' * v + '- ' for k, v in indentspaces.items() }
+        paramsindent = { k: ' ' * v + '  ' for k, v in indentspaces.items() }
+
+        def printParams(parameters: Dict[str, Node], level: str):
+            for k, v in parameters.items():
+                print('{}{}: {}'.format(paramsindent[level], k, v))
 
         for hsnName, hsn in self.heatStorageNodes.items():
             print('{}{}'.format(indent['HSN'], hsnName))
+            printParams(hsn.parameters, 'HSN')
+
             for ifnName, ifn in hsn.interfaces.items():
                 print('{}{}'.format(indent['IFN'], ifnName))
+                printParams(ifn.parameters, 'IFN')
+
                 for linkName, link in ifn.interfaceLinks.items():
                     print('{}{}'.format(indent['link'], linkName))
+                    printParams(link.parameters, 'link')

--- a/thermalmodel/thermalmodel.py
+++ b/thermalmodel/thermalmodel.py
@@ -202,3 +202,18 @@ class ThermalModel():
             [ self.temperatureReadings, pd.DataFrame(reading) ],
             ignore_index=True,
         )
+
+    def display(self):
+        indentspaces = {
+            'HSN': 0,
+            'IFN': 4,
+            'link': 8,
+        }
+        indent = { k: ' ' * v + '- ' for k, v in indentspaces.items() }
+
+        for hsnName, hsn in self.heatStorageNodes.items():
+            print('{}{}'.format(indent['HSN'], hsnName))
+            for ifnName, ifn in hsn.interfaces.items():
+                print('{}{}'.format(indent['IFN'], ifnName))
+                for linkName, link in ifn.interfaceLinks.items():
+                    print('{}{}'.format(indent['link'], linkName))


### PR DESCRIPTION
# Solution

Here presented is the implementation for the tree view. It essentially traverses the hierarchy from HSN → IFN → Link and displays the names attributed to them, as well as their parameters.

# Remaining Problem

An issue lies in displaying the Link parameters. Two of it's attributes are `node1` and `node2` which holds a reference to the IFNs the the link connects. The IFN holds a reference (`referenceNode` attribute) to the HSN it belongs to. This reference can be used to [extract the IFN's name](https://github.com/niveK77pur/ISM-Thermal-Model/commit/c05cf711357479b70fff315351e48dd627fcd1db) from the HSN's `interfaces` attribute.

However, the HSN's name is stored within the `ThermalModel`'s `heatStorageNodes` attribute, but there is no reference allowing to traverse upwards to the ThermalModel instance.

It would not make sense &ndash; conceptually speaking &ndash; to add such a reference to the parent `ThermalModel` instance. Hence it might be of interest to add name attributes to all the `Node` (and it's sub-classes) and `Link` class to allow for generation of complete model information.